### PR TITLE
Add main application version on config.dat file

### DIFF
--- a/lib/cloudwalk_setup.rb
+++ b/lib/cloudwalk_setup.rb
@@ -26,6 +26,7 @@ class CloudwalkSetup
     if update_process_in_progess? || !AdminConfiguration.device_activated?
       AdminConfiguration.configure_payment_application
     end
+    Device::Setting.update_attributes('main_app_version' => Main.version)
   end
 
   def self.setup_listeners


### PR DESCRIPTION
In some situations is necessary to know main application version in the payment application context.