### PR TITLE
Emv table handler

### DIFF
--- a/lib/cloudwalk_setup.rb
+++ b/lib/cloudwalk_setup.rb
@@ -458,6 +458,8 @@ class CloudwalkSetup
   end
 
   def self.setup_events
+    major, min, patch = Device.version.to_s.split('.').map { |v| v.to_i }
+
     if InputTransactionAmount.enabled? && InputTransactionAmount.emv_ctls_table_installed?
       DaFunk::EventHandler.new :touchscreen, {:x => 41..199, :y => 179..233} do
         InputTransactionAmount.call
@@ -475,7 +477,11 @@ class CloudwalkSetup
     end
 
     if Device::System.model == "s920"
-      DaFunk::EventHandler.new :key_main, Device::IO::ALPHA  do AdminConfiguration.perform      end
+      if (major == 8 && min >= 1) || major > 8
+        DaFunk::EventHandler.new :key_main, Device::IO::ALPHA  do CloudwalkSetup.start      end
+      else
+        DaFunk::EventHandler.new :key_main, Device::IO::ALPHA  do AdminConfiguration.perform      end
+      end
     end
 
     DaFunk::EventHandler.new :key_main, Device::IO::CLEAR do Device::Printer.paperfeed       end

--- a/lib/cloudwalk_setup.rb
+++ b/lib/cloudwalk_setup.rb
@@ -171,6 +171,16 @@ class CloudwalkSetup
       CloudwalkUpdate.application
     end
 
+    # Because payment application can update the table and it's running in other runtime instance
+    DaFunk::EventHandler.new :file_exists, './shared/emv_table_reload' do
+      if EmvTransaction.opened?
+        EmvTransaction.load('4')
+      else
+        EmvTransaction.boot
+      end
+      File.delete('./shared/emv_table_reload') if File.exists?('./shared/emv_table_reload')
+    end
+
     DaFunk::EventListener.new :file_exists_once do |event|
       event.start do @file_exists_once = {}; true end
 

--- a/lib/cloudwalk_setup.rb
+++ b/lib/cloudwalk_setup.rb
@@ -428,16 +428,22 @@ class CloudwalkSetup
       if File.exists?(schedule_path)
         schedule_params = JSON.parse(File.read(schedule_path))
         schedule_params["routines"].each do |params|
+          schedule_interval = {}
           ruby_app      = params["app"]
           function      = {
                             initialize: params["routine"]["initialize"],
                             parameters: params["routine"]["parameters"]
                           }
           interval      = params["routine"]["interval"].to_i
+          if params["routine"]["type_time"] == 'minutes'
+            schedule_interval[:minutes] = interval
+          else
+            schedule_interval[:seconds] = interval
+          end
           file_check    = params["routine"]["file_check"]
           function_boot = { :initialize => params["routine"]["boot"] }
 
-          DaFunk::EventHandler.new :schedule, seconds: interval do
+          DaFunk::EventHandler.new :schedule, schedule_interval do
             Device::Runtime.execute(ruby_app, function.to_json)
           end
 

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -9,6 +9,8 @@ class Main < Device
     case self.execute(json)
     when :admin_configuration
       AdminConfiguration.perform
+    when :main_menu
+      AdminConfiguration.main_menu
     when :admin_communication
       AdminConfiguration.communication
     when :communication
@@ -55,6 +57,8 @@ class Main < Device
         :system_update
       elsif options["initialize"] == "send_logs"
         :send_logs
+      elsif options["initialize"] == "main_menu"
+        :main_menu
       else
         :normal
       end


### PR DESCRIPTION
- Added new handler that reloads emv table if emv_table_reload file exists
- Added possibility of scheduling a ruby application task in minutes (currently is possible to do that just in seconds)
- Remap menu# button to access the payment application instead main menu, only for versions >= 8.1.X and S920 model only
- Added possibility of accessing the main menu without password (because the payment application is already doing the validation)